### PR TITLE
Update: Disable buildstats in devmode

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -20,7 +20,7 @@ defaultContentLanguageInSubdir = false
 copyRight = "Copyright (c) 2022-2024 Defensive Lab Agency"
 
 [build.buildStats]
-  enable = true
+  enable = false
 
 [outputs]
   home = ["HTML", "RSS", "searchIndex"]

--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,3 +1,6 @@
 # Overrides for production environment
 #baseurl = https://pts-project.org
 #canonifyURLs = true
+
+[build.buildStats]
+  enable = true


### PR DESCRIPTION
Disable hugo `build.buildStats` in default. Override it in production deployments only. 