### PR TITLE
Fix “opt-out” vs. “opt out” (verb).

### DIFF
--- a/content/blog/Monthly report #26 - 2024-03/index.md
+++ b/content/blog/Monthly report #26 - 2024-03/index.md
@@ -34,7 +34,7 @@ We created a dashboard keeping track of a few KPIs providing us with a rough est
 We are hosting a beta version of Colander which is open to community members. Feel free to ask for an account.
 
 # What we plan to do next month
-* continue working on the implementation of a privacy-preserving telemetry for PiRogue and Colander users can opt-out
+* continue working on the implementation of a privacy-preserving telemetry for PiRogue and Colander users can opt out
 * continue testing and fixing bugs
 * continue working on the project documentation
 

--- a/content/blog/Monthly report #27 - 2024-04/index.md
+++ b/content/blog/Monthly report #27 - 2024-04/index.md
@@ -14,7 +14,7 @@ You can check out our work on GitHub at [https://github.com/PiRogueToolSuite/](h
 
 ## PiRogue
 
-We have implemented the privacy preserving telemetry which is now installed by default. Users can easily opt-out as described in [the documentation](https://pts-project.org/docs/pirogue/telemetry/).
+We have implemented the privacy preserving telemetry which is now installed by default. Users can easily opt out as described in [the documentation](https://pts-project.org/docs/pirogue/telemetry/).
 
 We have published the [dependency tree](https://pts-project.org/docs/pirogue/operating-system/#packaging-for-pirogue) of the PiRogue Debian packages. This way, users can know what will be installed.
 

--- a/content/guides/g1/index.md
+++ b/content/guides/g1/index.md
@@ -177,7 +177,7 @@ If you're setting up the PiRogue in the context of an organization at your offic
 After the reboot, wait a few minutes, you will then be able to connect a Wi-Fi device and use the PiRogue’s dashboard.
 
 {{< callout context="danger" title="Important note about telemetry" icon="alert-octagon" >}}
-The telemetry is enabled by default but you can easily opt-out. Find more details in the [section dedicated to the telemetry](/docs/pirogue/telemetry/).
+The telemetry is enabled by default but you can easily opt out. Find more details in the [section dedicated to the telemetry](/docs/pirogue/telemetry/).
 {{< /callout >}}
 
 First, connect a wi-fi device such as your smartphone to the PiRogue's wi-fi network `PiRogue1` (default password: `superlongkey`). Next, open the PiRogue's dashboard by going at `http://<PiRogue IP address>:3000` (default credentials: `admin:PiRogue`) with your Web browser or directly with this link:


### PR DESCRIPTION
Trivial fixes, as discussed.