### PR TITLE
Contributing page & Community Navbar item (Fixes #252)

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -37,6 +37,31 @@
   weight = 25
 
 [[main]]
+  name = "Community"
+  url = ""
+  weight = 29
+
+[[main]]
+  name = "Contribute"
+  url = "/contributing/"
+  weight = 10
+  parent = "Community"
+
+[[main]]
+  name = "Discord"
+  url = "https://discord.com/invite/qGX73GYNdp"
+  weight = 20
+  parent = "Community"
+
+[[main]]
+  name = "Open Collective"
+  url = "https://opencollective.com/pts"
+  weight = 30
+  parent = "Community"
+
+
+
+[[main]]
   name = "Team"
   url = "/team/"
   weight = 20

--- a/content/contributing/index.md
+++ b/content/contributing/index.md
@@ -1,0 +1,40 @@
+---
+description: "How to Contribute."
+date: 2024-08-17
+lastmod: 2024-08-17
+draft: false
+toc: false
+images: []
+---
+
+# How to Contribute
+This page outlines various ways you can get involved with PiRogue tool suite (PTS) project, including contributing code, improving documentation, assisting others, and providing financial support. Before diving in, remember to read the [Code of Conduct](/code-of-conduct).
+
+## Contribute to Code
+The PiRogue tool suite (PTS) project code resides on GitHub at [github.com/PiRogueToolSuite](https://github.com/PiRogueToolSuite).
+
+## Report Issues or Request Features
+
+* **Encountered a bug?** Let us know! Submit a bug report describing the issue.
+
+* **Have an idea for a new feature?** We'd love to hear it! Submit a feature request detailing your proposal.
+
+## Create a Pull Request
+
+* **Planning a significant code change?** Reach out to the maintainer before submitting your pull request.
+
+* **Follow the recommended workflow:** Use the established [GitHub flow](https://www.conventionalcommits.org/en/v1.0.0/) when submitting your code.
+* **Write clear commit messages:** Adhere to the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/) for well-structured commit messages.
+
+
+## Improve Documentation
+
+The PiRogue tool suite (PTS) project documentation resides in this [gitHub repository](https://github.com/PiRogueToolSuite/piroguetoolsuite.github.io/). Feel free to submit pull requests to improve existing documentation or add new content!. 
+
+## Help Others and Get Help
+
+[Discord](https://discord.gg/qGX73GYNdp) is the primary platform for PiRogue tool suite (PTS) project community discussions. Join the Discord server to seek help or lend a hand to fellow users!
+
+## Contribute Financially
+
+Show your support for the PTS Project development team by becoming a [financial contributor](https://opencollective.com/pts).


### PR DESCRIPTION
Add 'How to contribute' page with content inspired by GetDoks contribute page. 

Introduce a 'Community' top level Navigation item. Along with 'Contribute', 'Discord' and 'Open Collective' sub items.

Fixes #252