### PR TITLE
Add Section Navigation (Fixes #223)

### DIFF
--- a/content/docs/pirogue/app_analysis/index.md
+++ b/content/docs/pirogue/app_analysis/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 100
+weight: 755
 toc: true
 ---
 

--- a/content/docs/pirogue/architecture/index.md
+++ b/content/docs/pirogue/architecture/index.md
@@ -4,7 +4,7 @@ draft: false
 menu:
   docs:
     parent: "pirogue"
-weight: 15
+weight: 705
 toc: true
 ---
 

--- a/content/docs/pirogue/cheatsheet.md
+++ b/content/docs/pirogue/cheatsheet.md
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 150
+weight: 760
 toc: true
 ---
 

--- a/content/docs/pirogue/configure/index.md
+++ b/content/docs/pirogue/configure/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 40
+weight: 730
 toc: true
 resources:
 - name: no_configuration

--- a/content/docs/pirogue/dashboard/index.md
+++ b/content/docs/pirogue/dashboard/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 60
+weight: 740
 toc: true
 ---
 

--- a/content/docs/pirogue/device_forensic/index.md
+++ b/content/docs/pirogue/device_forensic/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 80
+weight: 745
 toc: true
 ---
 

--- a/content/docs/pirogue/export_data/index.md
+++ b/content/docs/pirogue/export_data/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 70
+weight: 740
 toc: true
 ---
 

--- a/content/docs/pirogue/hardware/index.md
+++ b/content/docs/pirogue/hardware/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 20
+weight: 710
 toc: true
 ---
 The PiRogue's core hardware consists of a Raspberry Pi 4, a versatile single-board computer, enhanced with a custom-designed HAT (Hardware Attachment on Top). This HAT serves as an expansion board that seamlessly integrates with the Raspberry Pi, providing additional functionalities and enhancing its capabilities. It features a TFT screen, a Real-Time Clock (RTC), and cooling fan control circuitry.

--- a/content/docs/pirogue/os/index.md
+++ b/content/docs/pirogue/os/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 30
+weight: 715
 toc: true
 ---
 

--- a/content/docs/pirogue/overview/index.md
+++ b/content/docs/pirogue/overview/index.md
@@ -4,7 +4,7 @@ draft: false
 menu:
   docs:
     parent: "pirogue"
-weight: 10
+weight: 700
 toc: true
 ---
 

--- a/content/docs/pirogue/pre-installed_tools.md
+++ b/content/docs/pirogue/pre-installed_tools.md
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 170
+weight: 770
 toc: true
 ---
 

--- a/content/docs/pirogue/setup.md
+++ b/content/docs/pirogue/setup.md
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 35
+weight: 720
 toc: true
 ---
 

--- a/content/docs/pirogue/telemetry.md
+++ b/content/docs/pirogue/telemetry.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 35
+weight: 725
 toc: true
 ---
 

--- a/content/docs/pirogue/traffic_analysis/index.md
+++ b/content/docs/pirogue/traffic_analysis/index.md
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 50
+weight: 735
 toc: true
 ---
 

--- a/content/docs/pirogue/traffic_capture/index.md
+++ b/content/docs/pirogue/traffic_capture/index.md
@@ -5,7 +5,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 90
+weight: 750
 toc: true
 ---
 

--- a/content/docs/pirogue/useful-commands.md
+++ b/content/docs/pirogue/useful-commands.md
@@ -7,7 +7,7 @@ images: []
 menu:
   docs:
     parent: "pirogue"
-weight: 160
+weight: 765
 toc: true
 ---
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -66,13 +66,11 @@
 				{{ end -}}
 			</div>
 			<!-- {{ partial "main/docs-navigation.html" . }} -->
-			<!--
 			{{ if not .Site.Params.options.collapsibleSidebar -}}
 				{{ partial "main/docs-navigation.html" . }}
 			{{ else -}}
 				<div class="my-n3"></div>
 			{{ end -}}
-			-->
 		</main>
 		{{ if and (eq site.Params.doks.containerBreakpoint "fluid") (in .Site.Params.mainSections .Type) }}
 			</div>


### PR DESCRIPTION
Makes it easy to navigate between pages using section next previous links 
* Add `main/docs-navigation.html` fargment 
* Enables docs-navigation fragment in `single.html`
* Change all Pirogue page weights to higher values to fix navigation problems.

Fixes #223