### PR TITLE
Fix duplicate instructions.

### DIFF
--- a/content/guides/g1/index.md
+++ b/content/guides/g1/index.md
@@ -164,8 +164,6 @@ Once connected, you have to finalize the installation of your PiRogue by running
 | `sudo apt dist-upgrade -y`         | Upgrade the entire operating system and all additional installed software |
 | `sudo apt install pirogue-base -y` | Install the PiRogue packages/features                                     |
 | `sudo reboot`                      | Reboot the PiRogue                                                        |
-| `sudo apt install pirogue-base -y` | Install the PiRogue packages/features                                     |
-| `sudo reboot`                      | Reboot the PiRogue                                                        |
 
 During the installation, when prompted, you will have to answer:
 * `No` to save firewall rules for IP v4


### PR DESCRIPTION
The same file was modified in the base branch and in a merged branch, which led to duplicate lines after the merge.

---

See `git show cdc4930d835545b1c37ac1f7b70d03de5d268390`