### PR TITLE
Bootstrap tooltips (Fixes #247)

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,1 +1,8 @@
 // Put your custom JS code here
+
+// Enable Bootstrap tooltips
+import { Tooltip } from 'bootstrap';
+
+const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+// eslint-disable-next-line no-unused-vars
+const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new Tooltip(tooltipTriggerEl))

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -43,7 +43,7 @@ footer = ""
   alertDismissable = true # true (default) or false
 
   # Bootstrap
-  bootstrapJavascript = false # false (default) or true
+  bootstrapJavascript = true # false (default) or true
 
   # Nav
   sectionNav = ["docs"] # ["docs"] (default) or list of sections (e.g. ["docs", "guides"])


### PR DESCRIPTION
Enable Bootstrap JavaScript tool tips on hover for bootstrap content. 

``` 
[Hover the mouse](https://example.com "This is a tooltip")
```
Fixes #247