### PR TITLE
Replace `curl -o` with `wget -O`.

### DIFF
--- a/content/docs/pirogue/os/index.md
+++ b/content/docs/pirogue/os/index.md
@@ -113,8 +113,8 @@ $ sudo reboot
 
 To convert a regular PC into a PiRogue, it requires Debian 12 being installed without any graphical environment and to add the PTS PPA with commands 
 ```bash
-$ sudo curl -o /etc/apt/sources.list.d/pirogue.list    https://pts-project.org/debian-12/pirogue.list
-$ sudo curl -o /etc/apt/trusted.gpg.d/pirogue.gpg   https://pts-project.org/debian-12/pirogue.gpg
+$ sudo wget -O /etc/apt/sources.list.d/pirogue.list https://pts-project.org/debian-12/pirogue.list
+$ sudo wget -O /etc/apt/trusted.gpg.d/pirogue.gpg   https://pts-project.org/debian-12/pirogue.gpg
 ```
 
 And finally install the PiRogue packages with the commands 

--- a/content/docs/recipes/pirogue-pc/index.md
+++ b/content/docs/recipes/pirogue-pc/index.md
@@ -46,8 +46,8 @@ run `iw list`and scroll through its output to check if the wireless interface su
 Next, we have to add the PTS PPA (repository containing all PiRogue packages) by running 
 
 ```bash
-sudo curl -o /etc/apt/sources.list.d/pirogue.list https://pts-project.org/debian-12/pirogue.list
-sudo curl -o /etc/apt/trusted.gpg.d/pirogue.gpg   https://pts-project.org/debian-12/pirogue.gpg
+sudo wget -O /etc/apt/sources.list.d/pirogue.list https://pts-project.org/debian-12/pirogue.list
+sudo wget -O /etc/apt/trusted.gpg.d/pirogue.gpg   https://pts-project.org/debian-12/pirogue.gpg
 sudo apt update
 ```
 


### PR DESCRIPTION
We're already making sure wget is installed in Pi images, and it's also the one that can be expected to be installed in virtually all Debian environments, as it's `Priority: standard` while curl is only `Priority: optional`.

(In passing, align URLs in content/docs/pirogue/os/index.md)