### PR TITLE
Add date to pcaps

### DIFF
--- a/content/docs/pirogue/traffic_capture/index.md
+++ b/content/docs/pirogue/traffic_capture/index.md
@@ -15,7 +15,7 @@ With the PiRogue, it is quite easy to capture the entire network traffic of any 
 
 The command 
 ```bash
-$ tcpdump -i wlan0 -w capture.pcap
+$ tcpdump -i wlan0 -w $(date +%Y%m%d%H%M)_capture.pcap
 ```
 instructs the `tcpdump` utility to capture network traffic from the wireless interface `wlan0` and store the captured data in a file named `capture.pcap`.
 

--- a/content/guides/g2/index.md
+++ b/content/guides/g2/index.md
@@ -75,7 +75,7 @@ To begin capturing the network traffic, we need to connect the device to the PiR
 Throughout this period, we will be using the tool **tcpdump** to capture the network traffic. After a duration of 3 days, we will retrieve the file containing all the captured network traffic. This file is typically named a **PCAP** file, which can be opened with tools like **Wireshark**.
 
 ```bash {title="Save the entire network traffic into a single file"}
-sudo tcpdump -i wlan0 -w example.pcap
+sudo tcpdump -i wlan0 -w $(date +%Y%m%d%H%M)_capture.pcap
 ```
 
 Now turn on the Wi-Fi connection of the device and connect to the PiRogue network.

--- a/content/guides/g8/index.md
+++ b/content/guides/g8/index.md
@@ -158,7 +158,7 @@ Don't launch the application.
 ### Instrument and intercept
 Once the application to be analyzed is installed on your Android device, connect your device to the PiRogue Wi-Fi network and run the following command:
 ```bash
-pirogue-intercept-gated -o <path to the output directory>
+pirogue-intercept-gated -o $(date +%Y%m%d%H%M)_output
 ```
 
 {{< callout context="danger" title="Limitations" icon="alert-octagon" >}}


### PR DESCRIPTION
Add date to pcap files generated by `pirogue-intercept-*`  and `tcpdump` command line tools . This would ensure the files are not overwritten by subsequent captures.

Fixes https://github.com/PiRogueToolSuite/piroguetoolsuite.github.io/issues/287