### PR TITLE
Mention the wireshark-common prompt for non-Pi installations.

### DIFF
--- a/content/docs/pirogue/setup.md
+++ b/content/docs/pirogue/setup.md
@@ -66,6 +66,10 @@ sudo apt-get update
 sudo apt-get install pirogue-base
 ```
 
+During the installation, if prompted, you will have to answer:
+
+- `Yes` to allow non-superusers to capture network traffic.
+
 Afterwards, the complete configuration can be inspected using the following
 command (no need to be `root`):
 
@@ -118,6 +122,10 @@ sudo wget -O /etc/apt/trusted.gpg.d/pirogue.gpg   https://pts-project.org/debian
 sudo apt-get update
 sudo apt-get install pirogue-base
 ```
+
+During the installation, if prompted, you will have to answer:
+
+- `Yes` to allow non-superusers to capture network traffic.
 
 Afterwards, the complete configuration can be inspected using the following
 command (no need to be `root`):


### PR DESCRIPTION
That's not shown with Pi images since we're preseeding answers there.

That wasn't shown during ViRogue preparations since the dependencies were different.

With the new dependencies in pirogue-base 2.0.4, this one prompt is back.

Both v4/v6 prompts from iptables-persistent are a thing from the past though, as it's no longer listed in dependencies.